### PR TITLE
Feature/simcom

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+modemmanager (1.18.6-1~bpo11+1-wb1) bullseye-backports; urgency=medium
+
+  * Add SIM A7600E-H support
+    - CGDCONT read response with only 3 parameters in list (+CGDCONT: 1,"IP","nate.sktelecom.com") parsing.
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.ru>  Fri, 22 Jul 2022 10:28:54 +0500
+
 modemmanager (1.18.6-1~bpo11+1) bullseye-backports; urgency=medium
 
   * Create backport for Debian 11.

--- a/debian/control
+++ b/debian/control
@@ -23,6 +23,7 @@ Build-Depends: debhelper-compat (= 13),
                python3-dbus,
                python3-gi,
                valac (>= 0.22),
+               libgpiod-dev,
 # Needed for building documentation
                gtk-doc-tools <!nodoc>,
                libglib2.0-doc <!nodoc>,

--- a/debian/rules
+++ b/debian/rules
@@ -24,7 +24,8 @@ override_dh_auto_configure:
 		--with-polkit=permissive \
 		--enable-more-warnings \
 		--with-suspend-resume=systemd \
-		--with-systemdsystemunitdir=/lib/systemd/system
+		--with-systemdsystemunitdir=/lib/systemd/system \
+		--disable-Werror
 
 override_dh_strip:
 	dh_strip --dbgsym-migration='modemmanager-dbg (<< 1.4.14-1~)'

--- a/plugins/Makefile.am
+++ b/plugins/Makefile.am
@@ -1423,7 +1423,7 @@ libmm_plugin_simtech_la_CPPFLAGS = \
 	-DMM_MODULE_NAME=\"simtech\" \
 	$(NULL)
 libmm_plugin_simtech_la_LDFLAGS = $(PLUGIN_COMMON_LINKER_FLAGS)
-libmm_plugin_simtech_la_LIBADD = $(builddir)/libhelpers-simtech.la
+libmm_plugin_simtech_la_LIBADD = $(builddir)/libhelpers-simtech.la -lgpiod
 
 dist_udevrules_DATA += simtech/77-mm-simtech-port-types.rules
 

--- a/plugins/Makefile.in
+++ b/plugins/Makefile.in
@@ -3080,7 +3080,7 @@ TEST_COMMON_LIBADD_FLAGS = \
 @ENABLE_PLUGIN_SIMTECH_TRUE@	$(NULL)
 
 @ENABLE_PLUGIN_SIMTECH_TRUE@libmm_plugin_simtech_la_LDFLAGS = $(PLUGIN_COMMON_LINKER_FLAGS)
-@ENABLE_PLUGIN_SIMTECH_TRUE@libmm_plugin_simtech_la_LIBADD = $(builddir)/libhelpers-simtech.la
+@ENABLE_PLUGIN_SIMTECH_TRUE@libmm_plugin_simtech_la_LIBADD = $(builddir)/libhelpers-simtech.la -lgpiod
 @ENABLE_PLUGIN_TELIT_TRUE@libmm_plugin_telit_la_SOURCES = \
 @ENABLE_PLUGIN_TELIT_TRUE@	telit/mm-plugin-telit.c \
 @ENABLE_PLUGIN_TELIT_TRUE@	telit/mm-plugin-telit.h \

--- a/plugins/simtech/77-mm-simtech-port-types.rules
+++ b/plugins/simtech/77-mm-simtech-port-types.rules
@@ -56,4 +56,11 @@ ATTRS{idVendor}=="1e0e", ATTRS{idProduct}=="9206", ENV{.MM_USBIFNUM}=="05", SUBS
 # Disable CPOL based features
 ATTRS{idVendor}=="1e0e", ATTRS{idProduct}=="9206", ENV{ID_MM_PREFERRED_NETWORKS_CPOL_DISABLED}="1"
 
+# SIM A7600E-H
+ATTRS{idVendor}=="1e0e", ATTRS{idProduct}=="9011", ENV{.MM_USBIFNUM}=="02", ENV{ID_MM_PORT_IGNORE}="1"
+ATTRS{idVendor}=="1e0e", ATTRS{idProduct}=="9011", ENV{.MM_USBIFNUM}=="04", ENV{ID_MM_PORT_TYPE_AT_PRIMARY}="1"
+ATTRS{idVendor}=="1e0e", ATTRS{idProduct}=="9011", ENV{.MM_USBIFNUM}=="04", ENV{ID_MM_TTY_FLOW_CONTROL}="none"
+ATTRS{idVendor}=="1e0e", ATTRS{idProduct}=="9011", ENV{.MM_USBIFNUM}=="05", ENV{ID_MM_PORT_TYPE_AT_PPP}="1"
+ATTRS{idVendor}=="1e0e", ATTRS{idProduct}=="9011", ENV{.MM_USBIFNUM}=="05", ENV{ID_MM_TTY_FLOW_CONTROL}="none"
+
 LABEL="mm_simtech_port_types_end"

--- a/plugins/simtech/mm-broadband-modem-simtech.c
+++ b/plugins/simtech/mm-broadband-modem-simtech.c
@@ -1061,6 +1061,42 @@ load_current_modes (MMIfaceModem        *self,
 }
 
 /*****************************************************************************/
+/* Load supported IP families (Modem interface) */
+
+static void
+load_supported_ip_families (MMIfaceModem *self,
+                            GAsyncReadyCallback callback,
+                            gpointer user_data)
+{
+    /* For SIM A7600E-H return all possible IP families without testing.
+       load_supported_ip_families is called once and SIM A7600E-H can return ERROR if internal logic is not ready
+       It will lead to errors during connection up in NetworkManager
+       So call callback without actual querying a modem
+     */
+    if (g_str_has_prefix (mm_iface_modem_get_model (self), "A7600E-H")) {
+        mm_obj_dbg (self, "loading supported IP families...");
+        callback(self, NULL, user_data);
+        return;
+    }
+    /* fallback to default implementation */
+    modem_load_supported_ip_families(self, callback, user_data);
+
+}
+
+static MMBearerIpFamily
+load_supported_ip_families_finish (MMIfaceModem *self,
+                                   GAsyncResult *res,
+                                   GError **error)
+{
+    /* For SIM A7600E-H return all possible IP families without testing */
+    if (g_str_has_prefix (mm_iface_modem_get_model (self), "A7600E-H")) {
+        return MM_BEARER_IP_FAMILY_IPV4 | MM_BEARER_IP_FAMILY_IPV6 | MM_BEARER_IP_FAMILY_IPV4V6;
+    }
+    /* fallback to default implementation */
+    return modem_load_supported_ip_families_finish(self, res, error);
+}
+
+/*****************************************************************************/
 /* Set allowed modes (Modem interface) */
 
 typedef struct {
@@ -1263,6 +1299,8 @@ iface_modem_init (MMIfaceModem *iface)
     iface->load_supported_modes_finish = load_supported_modes_finish;
     iface->load_current_modes = load_current_modes;
     iface->load_current_modes_finish = load_current_modes_finish;
+    iface->load_supported_ip_families = load_supported_ip_families;
+    iface->load_supported_ip_families_finish = load_supported_ip_families_finish;
     iface->set_current_modes = set_current_modes;
     iface->set_current_modes_finish = set_current_modes_finish;
 }

--- a/plugins/simtech/mm-broadband-modem-simtech.c
+++ b/plugins/simtech/mm-broadband-modem-simtech.c
@@ -81,7 +81,6 @@ typedef struct {
 } CPinResult;
 
 static CPinResult unlock_results[] = {
-    /* Longer entries first so we catch the correct one with strcmp() */
     { "READY",         MM_MODEM_LOCK_NONE           },
     { "SIM PIN2",      MM_MODEM_LOCK_SIM_PIN2       },
     { "SIM PUK2",      MM_MODEM_LOCK_SIM_PUK2       },
@@ -1186,7 +1185,7 @@ load_supported_ip_families_finish (MMIfaceModem *self,
 }
 
 /*****************************************************************************/
-/* Load sim slots (Modem interface) */
+/* Check unlock required (Modem interface) */
 
 static void
 mm_broadband_modem_simtech_cpin_query_ready (MMIfaceModem *_self,

--- a/src/mm-base-sim.c
+++ b/src/mm-base-sim.c
@@ -2115,7 +2115,7 @@ load_operator_identifier (MMBaseSim *self,
     mm_base_modem_at_command (
         self->priv->modem,
         "+CRSM=176,28589,0,0,4",
-        10,
+        20,
         FALSE,
         (GAsyncReadyCallback)load_operator_identifier_command_ready,
         g_task_new (self, NULL, callback, user_data));
@@ -2205,7 +2205,7 @@ load_operator_name (MMBaseSim *self,
     mm_base_modem_at_command (
         self->priv->modem,
         "+CRSM=176,28486,0,0,17",
-        10,
+        20,
         FALSE,
         (GAsyncReadyCallback)load_operator_name_command_ready,
         g_task_new (self, NULL, callback, user_data));

--- a/src/mm-base-sim.c
+++ b/src/mm-base-sim.c
@@ -2111,7 +2111,9 @@ load_operator_identifier (MMBaseSim *self,
 {
     mm_obj_dbg (self, "loading operator ID...");
 
-    /* READ BINARY of EFad (Administrative Data) ETSI 51.011 section 10.3.18 */
+    /* READ BINARY of EFad (Administrative Data) ETSI 51.011 section 10.3.18
+     * SIMCOM modems can answer in 10s or more, so use rather big timeout
+     */
     mm_base_modem_at_command (
         self->priv->modem,
         "+CRSM=176,28589,0,0,4",
@@ -2201,7 +2203,9 @@ load_operator_name (MMBaseSim *self,
 {
     mm_obj_dbg (self, "loading operator name...");
 
-    /* READ BINARY of EFspn (Service Provider Name) ETSI 51.011 section 10.3.11 */
+    /* READ BINARY of EFspn (Service Provider Name) ETSI 51.011 section 10.3.11
+     * SIMCOM modems can answer in 10s or more, so use rather big timeout
+     */
     mm_base_modem_at_command (
         self->priv->modem,
         "+CRSM=176,28486,0,0,17",

--- a/src/mm-modem-helpers.c
+++ b/src/mm-modem-helpers.c
@@ -1830,7 +1830,7 @@ mm_3gpp_parse_cgdcont_read_response (const gchar *reply,
         return NULL;
 
     list = NULL;
-    r = g_regex_new ("\\+CGDCONT:\\s*(\\d+)\\s*,([^, \\)]*)\\s*,([^, \\)]*)\\s*,([^, \\)]*)",
+    r = g_regex_new ("\\+CGDCONT:\\s*(\\d+)\\s*,([^, \\)]*)\\s*,([^,\\s\\)]*)",
                      G_REGEX_DOLLAR_ENDONLY | G_REGEX_RAW,
                      0, &inner_error);
     if (r) {

--- a/src/tests/test-modem-helpers.c
+++ b/src/tests/test-modem-helpers.c
@@ -2663,6 +2663,22 @@ test_cgdcont_read_response_samsung (void *f, gpointer d)
     test_cgdcont_read_results ("Samsung", reply, &expected[0], G_N_ELEMENTS (expected));
 }
 
+static void
+test_cgdcont_read_response_simcom (void *f, gpointer d)
+{
+    const gchar *reply =
+        "+CGDCONT: 1,\"IP\",\"nate.sktelecom.com\"\r\n"
+        "+CGDCONT: 2,\"IP\",\"epc.tmobile.com\"\r\n"
+        "+CGDCONT: 3,\"IP\",\"MAXROAM.com\"\r\n";
+    static MM3gppPdpContext expected[] = {
+        { 1, MM_BEARER_IP_FAMILY_IPV4, (gchar *) "nate.sktelecom.com" },
+        { 2, MM_BEARER_IP_FAMILY_IPV4, (gchar *) "epc.tmobile.com"    },
+        { 3, MM_BEARER_IP_FAMILY_IPV4, (gchar *) "MAXROAM.com"        }
+    };
+
+    test_cgdcont_read_results ("Simcom", reply, &expected[0], G_N_ELEMENTS (expected));
+}
+
 /*****************************************************************************/
 /* Test CGDCONT read responses */
 
@@ -4768,6 +4784,7 @@ int main (int argc, char **argv)
 
     g_test_suite_add (suite, TESTCASE (test_cgdcont_read_response_nokia, NULL));
     g_test_suite_add (suite, TESTCASE (test_cgdcont_read_response_samsung, NULL));
+    g_test_suite_add (suite, TESTCASE (test_cgdcont_read_response_simcom, NULL));
 
     g_test_suite_add (suite, TESTCASE (test_profile_selection, NULL));
 


### PR DESCRIPTION
Патчи для поддержки SIM A7600E-H:
1. Поправил разбор ответа на `AT+CGDCONT?`. Старый регэксп расчитывал, что есть минимум 4 параметра в ответе. По стандарту можно меньше. Наш модем присылает 3. В результате не работала процедура проверки того, что контекст создан.
2. Убрал `-Werror`. Вылезла куча мест, где компилятор ругается на преобразование выравнивания (`Wcast-align`). Возможно, надо как-то иначе собирать, но я не понял как. `dpkg-buildpackage -us -uc` приводит к этим ошибкам, без них всё собирается и работает.
3. MM запрашивает у модема типы IP адресов, которые тот поддерживает. Модем возвращает ошибку, если не зареган в сети. К сожалению, эта процедура выполняется один раз за всё время, и результат потом кэшируется. Получается так, что MM не видит ни одного типа IP адресов. При создании поключения NetworkManager офигевает от такого расклада и падает в сегфолт. Отдаю для SIM A7600E-H все возможные типы без запроса к модему. 