### PR TITLE
Feature/60532 modem restart

### DIFF
--- a/cli/mmcli-modem.c
+++ b/cli/mmcli-modem.c
@@ -1218,7 +1218,6 @@ get_modem_ready (GObject      *source,
 
     /* Request to switch SIM? */
     if (set_primary_sim_slot_int > 0) {
-
         mm_modem_set_primary_sim_slot (ctx->modem,
                                        set_primary_sim_slot_int,
                                        ctx->cancellable,

--- a/cli/mmcli-modem.c
+++ b/cli/mmcli-modem.c
@@ -1218,12 +1218,21 @@ get_modem_ready (GObject      *source,
 
     /* Request to switch SIM? */
     if (set_primary_sim_slot_int > 0) {
-        fprintf(stderr, "Simslot %d requested (async)", set_primary_sim_slot_int);
-        mm_modem_set_primary_sim_slot (ctx->modem,
-                                       set_primary_sim_slot_int,
-                                       ctx->cancellable,
-                                       (GAsyncReadyCallback)set_primary_sim_slot_ready,
-                                       NULL);
+        guint current_primary_slot;
+
+        current_primary_slot = mm_modem_get_primary_sim_slot (ctx->modem);
+        g_debug ("Switch primary slot %d -> %d is requested (async)",
+                 current_primary_slot, set_primary_sim_slot_int);
+        if (set_primary_sim_slot_int == current_primary_slot) {
+            set_primary_sim_slot_ready (ctx->modem, NULL);
+            g_debug ("Primary slot is already %d; doing nothing", current_primary_slot);
+        } else {
+            mm_modem_set_primary_sim_slot (ctx->modem,
+                                        set_primary_sim_slot_int,
+                                        ctx->cancellable,
+                                        (GAsyncReadyCallback)set_primary_sim_slot_ready,
+                                        NULL);
+        }
         return;
     }
 
@@ -1498,9 +1507,18 @@ mmcli_modem_run_synchronous (GDBusConnection *connection)
     /* Request to switch current SIM? */
     if (set_primary_sim_slot_int > 0) {
         gboolean result;
+        guint current_primary_slot;
 
-        fprintf(stderr, "Simslot %d requested (sync)", set_primary_sim_slot_int);
-        result = mm_modem_set_primary_sim_slot_sync (ctx->modem, set_primary_sim_slot_int, NULL, &error);
+        current_primary_slot = mm_modem_get_primary_sim_slot (ctx->modem);
+        g_debug ("Switch primary slot %d -> %d is requested (sync)",
+                 current_primary_slot, set_primary_sim_slot_int);
+        if (set_primary_sim_slot_int == current_primary_slot) {
+            g_debug ("Primary slot is already %d; doing nothing", current_primary_slot);
+            result = TRUE;
+        } else {
+            result = mm_modem_set_primary_sim_slot_sync (ctx->modem, set_primary_sim_slot_int, NULL, &error);
+        }
+
         set_primary_sim_slot_process_reply (result, error);
         return;
     }

--- a/cli/mmcli-modem.c
+++ b/cli/mmcli-modem.c
@@ -1218,6 +1218,7 @@ get_modem_ready (GObject      *source,
 
     /* Request to switch SIM? */
     if (set_primary_sim_slot_int > 0) {
+        fprintf(stderr, "Simslot %d requested (async)", set_primary_sim_slot_int);
         mm_modem_set_primary_sim_slot (ctx->modem,
                                        set_primary_sim_slot_int,
                                        ctx->cancellable,
@@ -1498,6 +1499,7 @@ mmcli_modem_run_synchronous (GDBusConnection *connection)
     if (set_primary_sim_slot_int > 0) {
         gboolean result;
 
+        fprintf(stderr, "Simslot %d requested (sync)", set_primary_sim_slot_int);
         result = mm_modem_set_primary_sim_slot_sync (ctx->modem, set_primary_sim_slot_int, NULL, &error);
         set_primary_sim_slot_process_reply (result, error);
         return;

--- a/cli/mmcli-modem.c
+++ b/cli/mmcli-modem.c
@@ -1218,21 +1218,12 @@ get_modem_ready (GObject      *source,
 
     /* Request to switch SIM? */
     if (set_primary_sim_slot_int > 0) {
-        guint current_primary_slot;
 
-        current_primary_slot = mm_modem_get_primary_sim_slot (ctx->modem);
-        g_debug ("Switch primary slot %d -> %d is requested (async)",
-                 current_primary_slot, set_primary_sim_slot_int);
-        if (set_primary_sim_slot_int == current_primary_slot) {
-            set_primary_sim_slot_ready (ctx->modem, NULL);
-            g_debug ("Primary slot is already %d; doing nothing", current_primary_slot);
-        } else {
-            mm_modem_set_primary_sim_slot (ctx->modem,
-                                        set_primary_sim_slot_int,
-                                        ctx->cancellable,
-                                        (GAsyncReadyCallback)set_primary_sim_slot_ready,
-                                        NULL);
-        }
+        mm_modem_set_primary_sim_slot (ctx->modem,
+                                       set_primary_sim_slot_int,
+                                       ctx->cancellable,
+                                       (GAsyncReadyCallback)set_primary_sim_slot_ready,
+                                       NULL);
         return;
     }
 
@@ -1507,18 +1498,8 @@ mmcli_modem_run_synchronous (GDBusConnection *connection)
     /* Request to switch current SIM? */
     if (set_primary_sim_slot_int > 0) {
         gboolean result;
-        guint current_primary_slot;
 
-        current_primary_slot = mm_modem_get_primary_sim_slot (ctx->modem);
-        g_debug ("Switch primary slot %d -> %d is requested (sync)",
-                 current_primary_slot, set_primary_sim_slot_int);
-        if (set_primary_sim_slot_int == current_primary_slot) {
-            g_debug ("Primary slot is already %d; doing nothing", current_primary_slot);
-            result = TRUE;
-        } else {
-            result = mm_modem_set_primary_sim_slot_sync (ctx->modem, set_primary_sim_slot_int, NULL, &error);
-        }
-
+        result = mm_modem_set_primary_sim_slot_sync (ctx->modem, set_primary_sim_slot_int, NULL, &error);
         set_primary_sim_slot_process_reply (result, error);
         return;
     }

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,7 +1,6 @@
 modemmanager (1.20.0-1~bpo11+1-wb103) stable; urgency=medium
 
-  * Fix SMS sending on SIM A7600E-H.
-    Some firmwares require setting character set of mobile equipment to GSM (AT+CSCS="GSM") before sending SMS.
+  * Check, is changing primary sim slot actually needed.
 
  -- Vladimir Romanov <v.romanov@wirenboard.com>  Thu, 20 Apr 2023 19:09:12 +0500
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+modemmanager (1.20.0-1~bpo11+1-wb103) stable; urgency=medium
+
+  * Fix SMS sending on SIM A7600E-H.
+    Some firmwares require setting character set of mobile equipment to GSM (AT+CSCS="GSM") before sending SMS.
+
+ -- Vladimir Romanov <v.romanov@wirenboard.com>  Thu, 20 Apr 2023 19:09:12 +0500
+
 modemmanager (1.20.0-1~bpo11+1-wb102) stable; urgency=medium
 
   * Fix SMS sending on SIM A7600E-H.
@@ -11,7 +18,7 @@ modemmanager (1.20.0-1~bpo11+1-wb101) bullseye-backports; urgency=medium
     - CGDCONT read response with only 3 parameters in list (+CGDCONT: 1,"IP","nate.sktelecom.com") parsing.
     - add UDEV rules for SIM A7600E-H
     - add SIM card switching using libgpiod.
-      Add ID_MM_SIM_SWITCH_GPIO_LABEL UDEV parameter for GPIO controlling external SIM switching 
+      Add ID_MM_SIM_SWITCH_GPIO_LABEL UDEV parameter for GPIO controlling external SIM switching
     - fix CGDCONT read response with only 3 parameters in list (+CGDCONT: 1,"IP","nate.sktelecom.com") parsing.
     - set all +CRSM response timeouts to 20s
     - ignore PB DONE, SMS DONE, +NITZ: URCs

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,6 @@
 modemmanager (1.20.0-1~bpo11+1-wb103) stable; urgency=medium
 
-  * Check, is changing primary sim slot actually needed.
+  * Check, is changing primary sim slot actually needed (simtech).
 
  -- Vladimir Romanov <v.romanov@wirenboard.com>  Thu, 20 Apr 2023 19:09:12 +0500
 

--- a/plugins/simtech/mm-broadband-modem-simtech.c
+++ b/plugins/simtech/mm-broadband-modem-simtech.c
@@ -1556,6 +1556,7 @@ mm_broadband_modem_simtech_set_primary_sim_slot (MMIfaceModem        *self,
             g_object_unref (task);
         } else {
             current_primary_slot = get_gpio_line_value (gpio_label, self) + 1;
+            gpiod_line_close_chip (line);
             if (current_primary_slot == sim_slot) {
                 g_task_return_new_error (task,
                                         MM_CORE_ERROR,
@@ -1563,7 +1564,6 @@ mm_broadband_modem_simtech_set_primary_sim_slot (MMIfaceModem        *self,
                                         "already on sim slot %d", current_primary_slot);
                 g_object_unref (task);
             } else {
-                gpiod_line_close_chip (line);
                 simtech_ignore_no_carrier(self, TRUE);
                 g_task_set_task_data (task, GUINT_TO_POINTER (sim_slot), NULL);
                 mm_base_modem_at_command (MM_BASE_MODEM (self),

--- a/plugins/simtech/mm-broadband-modem-simtech.c
+++ b/plugins/simtech/mm-broadband-modem-simtech.c
@@ -1555,8 +1555,8 @@ mm_broadband_modem_simtech_set_primary_sim_slot (MMIfaceModem        *self,
                                      "can't find gpio line '%s'", gpio_label);
             g_object_unref (task);
         } else {
-            current_primary_slot = get_gpio_line_value (gpio_label, self) + 1;
             gpiod_line_close_chip (line);
+            current_primary_slot = get_gpio_line_value (gpio_label, self) + 1;
             if (current_primary_slot == sim_slot) {
                 g_task_return_new_error (task,
                                         MM_CORE_ERROR,

--- a/plugins/simtech/mm-broadband-modem-simtech.c
+++ b/plugins/simtech/mm-broadband-modem-simtech.c
@@ -1541,6 +1541,7 @@ mm_broadband_modem_simtech_set_primary_sim_slot (MMIfaceModem        *self,
     GTask *task;
     const gchar *gpio_label = NULL;
     struct gpiod_line *line;
+    guint current_primary_slot;
 
     task = g_task_new (self, NULL, callback, user_data);
 
@@ -1554,23 +1555,7 @@ mm_broadband_modem_simtech_set_primary_sim_slot (MMIfaceModem        *self,
                                      "can't find gpio line '%s'", gpio_label);
             g_object_unref (task);
         } else {
-            guint current_primary_slot;
-            MmGdbusModem *skeleton;
-
-            g_object_get (self,
-                         MM_IFACE_MODEM_DBUS_SKELETON, &skeleton,
-                         NULL);
-            if (!skeleton) {
-                g_task_return_new_error (task,
-                                        MM_CORE_ERROR,
-                                        MM_CORE_ERROR_FAILED,
-                                        "Couldn't get interface skeleton");
-                g_object_unref (task);
-                return;
-            }
-            current_primary_slot = mm_gdbus_modem_get_primary_sim_slot (MM_GDBUS_MODEM (skeleton));
-            g_object_unref (skeleton);
-
+            current_primary_slot = get_gpio_line_value (gpio_label, self) + 1;
             if (current_primary_slot == sim_slot) {
                 g_task_return_new_error (task,
                                         MM_CORE_ERROR,

--- a/plugins/simtech/mm-broadband-modem-simtech.c
+++ b/plugins/simtech/mm-broadband-modem-simtech.c
@@ -105,7 +105,7 @@ static CPinResult unlock_results[] = {
     { NULL }
 };
 
-static void 
+static void
 simtech_ignore_no_carrier(MMIfaceModem *self,
                           gboolean enable)
 {
@@ -1554,15 +1554,40 @@ mm_broadband_modem_simtech_set_primary_sim_slot (MMIfaceModem        *self,
                                      "can't find gpio line '%s'", gpio_label);
             g_object_unref (task);
         } else {
-            gpiod_line_close_chip (line);
-            simtech_ignore_no_carrier(self, TRUE);
-            g_task_set_task_data (task, GUINT_TO_POINTER (sim_slot), NULL);
-            mm_base_modem_at_command (MM_BASE_MODEM (self),
-                                    "+CFUN=0",
-                                    9,
-                                    FALSE,
-                                    (GAsyncReadyCallback) mm_broadband_modem_simtech_disable_me_ready,
-                                    task);
+            guint current_primary_slot;
+            MmGdbusModem *skeleton;
+
+            g_object_get (self,
+                         MM_IFACE_MODEM_DBUS_SKELETON, &skeleton,
+                         NULL);
+            if (!skeleton) {
+                g_task_return_new_error (task,
+                                        MM_CORE_ERROR,
+                                        MM_CORE_ERROR_FAILED,
+                                        "Couldn't get interface skeleton");
+                g_object_unref (task);
+                return;
+            }
+            current_primary_slot = mm_gdbus_modem_get_primary_sim_slot (MM_GDBUS_MODEM (skeleton));
+            g_object_unref (skeleton);
+
+            if (current_primary_slot == sim_slot) {
+                g_task_return_new_error (task,
+                                        MM_CORE_ERROR,
+                                        MM_CORE_ERROR_EXISTS,
+                                        "already on sim slot %d", current_primary_slot);
+                g_object_unref (task);
+            } else {
+                gpiod_line_close_chip (line);
+                simtech_ignore_no_carrier(self, TRUE);
+                g_task_set_task_data (task, GUINT_TO_POINTER (sim_slot), NULL);
+                mm_base_modem_at_command (MM_BASE_MODEM (self),
+                                        "+CFUN=0",
+                                        9,
+                                        FALSE,
+                                        (GAsyncReadyCallback) mm_broadband_modem_simtech_disable_me_ready,
+                                        task);
+            }
         }
     } else {
         g_task_return_new_error (task,
@@ -1801,7 +1826,7 @@ static MMBaseSms *
 mm_broadband_modem_simtech_create_sms (MMIfaceModemMessaging *self)
 {
     if (g_str_has_prefix (mm_iface_modem_get_model (MM_IFACE_MODEM (self)), "A7600E-H")) {
-        return mm_sms_simtech_a7600_new (MM_BASE_MODEM (self)); 
+        return mm_sms_simtech_a7600_new (MM_BASE_MODEM (self));
     }
     return iface_modem_messaging_parent->create_sms(self);
 }


### PR DESCRIPTION
если требуемый primary_slot уже выбран - не переключаем его, чтобы модем не перезагружался

проверял через mmcli -m any --set-primary-sim-slot + minicom в модем в соседнем окне