### PR TITLE
Increase SMS reading timeout to 120 seconds

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+modemmanager (1.20.0-1~bpo11+1-wb105) stable; urgency=medium
+
+  * Increase SMS reading timeout to 120 seconds
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Wed, 10 May 2023 16:38:34 +0500
+
 modemmanager (1.20.0-1~bpo11+1-wb104) stable; urgency=medium
 
   * Add SIM A7602E-H support

--- a/src/mm-broadband-modem.c
+++ b/src/mm-broadband-modem.c
@@ -7685,7 +7685,7 @@ list_parts_lock_storages_ready (MMBroadbandModem *self,
                               (MM_BROADBAND_MODEM (self)->priv->modem_messaging_sms_pdu_mode ?
                                "+CMGL=4" :
                                "+CMGL=\"ALL\""),
-                              20,
+                              120,
                               FALSE,
                               (GAsyncReadyCallback) (MM_BROADBAND_MODEM (self)->priv->modem_messaging_sms_pdu_mode ?
                                                      sms_pdu_part_list_ready :


### PR DESCRIPTION
SIM-cards can store a lot of SMS's. 20 seconds is not sufficient to read them

Решение неоднозначное, т.к. существенно увеличивает время инициализации модема.
Альтернативы:
1. Читать не все смс, а только непрочитанные. Правда, тогда нельзя будет повторно прочитать смс.
2. Читать смс по запросу. Решение осложняется тем, что смс могут состоять из нескольких частей. ModemManager же хранит уже полные слитые смс. Неясно, как их читать по запросу. К тому же придётся сильно изменить текущий код MM.