### PR TITLE
Add SIMCOM A7600/A7602/A7608 USSD support

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+modemmanager (1.20.0-1~bpo11+1-wb106) stable; urgency=medium
+
+  * Add USSD support for SIM A7600E-H/A7602E-H
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Fri, 07 Jul 2023 11:42:05 +0500
+
 modemmanager (1.20.0-1~bpo11+1-wb105) stable; urgency=medium
 
   * Increase SMS reading timeout to 120 seconds

--- a/src/mm-broadband-modem.c
+++ b/src/mm-broadband-modem.c
@@ -6238,9 +6238,20 @@ cusd_process_string (MMBroadbandModem *self,
         break;
 
     case 2:
+        converted = decode_ussd_response (self, str, &error);
+        if (!converted) {
+            if (task)
+                error = g_error_new (MM_CORE_ERROR, MM_CORE_ERROR_ABORTED, "USSD terminated by network");
+            break;
+        }
+        
         /* Response to the user's request? */
         if (task)
-            error = g_error_new (MM_CORE_ERROR, MM_CORE_ERROR_ABORTED, "USSD terminated by network");
+            break;
+
+        /* Network-initiated USSD-Notify */
+        mm_iface_modem_3gpp_ussd_update_network_notification (MM_IFACE_MODEM_3GPP_USSD (self), converted);
+        g_clear_pointer (&converted, g_free);
         break;
 
     case 4:


### PR DESCRIPTION
* The modem expect data in CUSD command to GSM-7 encoded
* The modem returns status 2, when successfully receiving an USSD answer from the provider. Similar behavior is described for Telit modem here https://gitlab.freedesktop.org/mobile-broadband/ModemManager/-/issues/103

Для корректной работы надо прошивку B09 модема, которую пока не зарелизили.
![image](https://github.com/wirenboard/modemmanager/assets/86825564/ac3ac647-108c-46eb-9901-a1410a9a7977)
