### PR TITLE
Fix SMS receiving on SIM A7600E-H and A7602E-H

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+modemmanager (1.20.0-1~bpo11+1-wb106) stable; urgency=medium
+
+  * Fix SMS receiving on SIM A7600E-H and A7602E-H
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Tue, 11 Jul 2023 14:28:15 +0500
+
 modemmanager (1.20.0-1~bpo11+1-wb105) stable; urgency=medium
 
   * Increase SMS reading timeout to 120 seconds


### PR DESCRIPTION
Default ModemManager's CNMI set command (AT+CNMI=2,1,2,1,0) results to +CMS ERROR: 302. It is unsupported combination.

Note from A7600E-H/A7602E-H AT commands manual:
AT+CNMI=<mode>,[<mt>[,<bm>[,<ds>[,<bfr>]]]]
If set <mt>＝3 or <ds>＝1, make sure <mode>＝1.
If set <mt>=2, make sure <mode>=1 or 2, otherwise it will return error.

So use AT+CNMI=2,1,0,0,0 to receive +CMTI notifications