### PR TITLE
Fix SIM A7602E-H SMS storage selection.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+modemmanager (1.20.0-1~bpo11+1-wb106) stable; urgency=medium
+
+  * Fix SIM A7602E-H SMS storage selection.
+    SIM A7602E-H resets SMS storages to default SM, if they are omitted in AT+CPMS write command. So always send all 3 parameters.
+
+ -- Petr Krasnoshchekov <petr.krasnoshchekov@wirenboard.com>  Mon, 15 Jan 2024 11:14:20 +0500
+
 modemmanager (1.20.0-1~bpo11+1-wb105) stable; urgency=medium
 
   * Increase SMS reading timeout to 120 seconds

--- a/src/mm-broadband-modem.c
+++ b/src/mm-broadband-modem.c
@@ -257,6 +257,7 @@ struct _MMBroadbandModemPrivate {
     MMSmsStorage current_sms_mem1_storage;
     gboolean mem2_storage_locked;
     MMSmsStorage current_sms_mem2_storage;
+    MMSmsStorage current_sms_mem3_storage;
 
     /*<--- Modem Voice interface --->*/
     /* Properties */
@@ -6631,6 +6632,7 @@ cpms_query_ready (MMBroadbandModem *self,
     GError *error = NULL;
     MMSmsStorage mem1;
     MMSmsStorage mem2;
+    MMSmsStorage mem3;
 
     response = mm_base_modem_at_command_finish (MM_BASE_MODEM (self), res, &error);
     if (error) {
@@ -6643,6 +6645,7 @@ cpms_query_ready (MMBroadbandModem *self,
     if (!mm_3gpp_parse_cpms_query_response (response,
                                             &mem1,
                                             &mem2,
+                                            &mem3,
                                             &error)) {
         g_task_return_error (task, error);
     } else {
@@ -6650,6 +6653,7 @@ cpms_query_ready (MMBroadbandModem *self,
 
         self->priv->current_sms_mem1_storage = mem1;
         self->priv->current_sms_mem2_storage = mem2;
+        self->priv->current_sms_mem3_storage = mem3;
 
         mm_obj_dbg (self, "current storages initialized:");
 
@@ -6659,6 +6663,10 @@ cpms_query_ready (MMBroadbandModem *self,
 
         aux = mm_common_build_sms_storages_string (&mem2, 1);
         mm_obj_dbg (self, "  mem2 (write/send) storages:       '%s'", aux);
+        g_free (aux);
+
+        aux = mm_common_build_sms_storages_string (&mem3, 1);
+        mm_obj_dbg (self, "  mem3 (receive) storages:       '%s'", aux);
         g_free (aux);
 
         g_task_return_boolean (task, TRUE);
@@ -6779,6 +6787,7 @@ mm_broadband_modem_lock_sms_storages (MMBroadbandModem *self,
     gchar *cmd = NULL;
     gchar *mem1_str = NULL;
     gchar *mem2_str = NULL;
+    gchar *mem3_str = NULL;
 
     /* If storages are currently locked by someone else, just return an
      * error */
@@ -6807,6 +6816,7 @@ mm_broadband_modem_lock_sms_storages (MMBroadbandModem *self,
     /* Some modems may not support empty string parameters, then if mem1 is
      * UNKNOWN, and current sms mem1 storage has a valid value, we send again
      * the already locked mem1 value in place of an empty string.
+     * The same applies to mem2.
      * This way we also avoid to confuse the environment of other sync operation
      * that have potentially locked mem1 previously.
      */
@@ -6836,19 +6846,38 @@ mm_broadband_modem_lock_sms_storages (MMBroadbandModem *self,
         self->priv->mem2_storage_locked = TRUE;
         self->priv->current_sms_mem2_storage = mem2;
 
-        mem2_str = g_ascii_strup (mm_sms_storage_get_string (self->priv->current_sms_mem2_storage), -1);
+    } else if (self->priv->current_sms_mem2_storage != MM_SMS_STORAGE_UNKNOWN) {
+        mm_obj_dbg (self, "given sms mem2 storage is unknown. Using current sms mem2 storage value '%s' instead",
+                    mm_sms_storage_get_string (self->priv->current_sms_mem2_storage));
+    } else {
+        g_task_return_new_error (task,
+                                 MM_CORE_ERROR,
+                                 MM_CORE_ERROR_RETRY,
+                                 "Cannot lock mem1 storage alone when current mem2 storage is unknown");
+        g_object_unref (task);
+        return;
     }
+    mem2_str = g_ascii_strup (mm_sms_storage_get_string (self->priv->current_sms_mem2_storage), -1);
+
+    /* Some modems reset mem3 to default if omitted. So always send it */
+    if (self->priv->current_sms_mem3_storage == MM_SMS_STORAGE_UNKNOWN) {
+        g_task_return_new_error (task,
+                                 MM_CORE_ERROR,
+                                 MM_CORE_ERROR_RETRY,
+                                 "Cannot lock mem1 or mem2 storage when current mem3 storage is unknown");
+        g_object_unref (task);
+        return;
+    }
+    mem3_str = g_ascii_strup (mm_sms_storage_get_string (self->priv->current_sms_mem3_storage), -1);
 
     g_assert (mem1_str != NULL);
+    g_assert (mem2_str != NULL);
+    g_assert (mem3_str != NULL);
 
-    /* We don't touch 'mem3' here */
-    mm_obj_dbg (self, "locking SMS storages to: mem1 (%s), mem2 (%s)...",
-                mem1_str, mem2_str ? mem2_str : "none");
+    mm_obj_dbg (self, "locking SMS storages to: mem1 (%s), mem2 (%s), mem2 (%s)",
+                mem1_str, mem2_str, mem3_str);
 
-    if (mem2_str)
-        cmd = g_strdup_printf ("+CPMS=\"%s\",\"%s\"", mem1_str, mem2_str);
-    else
-        cmd = g_strdup_printf ("+CPMS=\"%s\"", mem1_str);
+    cmd = g_strdup_printf ("+CPMS=\"%s\",\"%s\",\"%s\"", mem1_str, mem2_str, mem3_str);
 
     mm_base_modem_at_command (MM_BASE_MODEM (self),
                               cmd,
@@ -6858,6 +6887,7 @@ mm_broadband_modem_lock_sms_storages (MMBroadbandModem *self,
                               task);
     g_free (mem1_str);
     g_free (mem2_str);
+    g_free (mem3_str);
     g_free (cmd);
 }
 
@@ -6913,6 +6943,7 @@ modem_messaging_set_default_storage (MMIfaceModemMessaging *_self,
 
     /* Set defaults as current */
     self->priv->current_sms_mem2_storage = storage;
+    self->priv->current_sms_mem3_storage = storage;
 
     mem1_str = g_ascii_strup (mm_sms_storage_get_string (self->priv->current_sms_mem1_storage), -1);
     mem_str = g_ascii_strup (mm_sms_storage_get_string (storage), -1);
@@ -13260,6 +13291,7 @@ mm_broadband_modem_init (MMBroadbandModem *self)
     self->priv->modem_messaging_sms_default_storage = MM_SMS_STORAGE_UNKNOWN;
     self->priv->current_sms_mem1_storage = MM_SMS_STORAGE_UNKNOWN;
     self->priv->current_sms_mem2_storage = MM_SMS_STORAGE_UNKNOWN;
+    self->priv->current_sms_mem3_storage = MM_SMS_STORAGE_UNKNOWN;
     self->priv->sim_hot_swap_supported = FALSE;
     self->priv->periodic_signal_check_disabled = FALSE;
     self->priv->periodic_access_tech_check_disabled = FALSE;

--- a/src/mm-modem-helpers.c
+++ b/src/mm-modem-helpers.c
@@ -3010,7 +3010,7 @@ mm_3gpp_parse_cpms_test_response (const gchar  *reply,
 
 /**********************************************************************
  * AT+CPMS?
- * +CPMS: <memr>,<usedr>,<totalr>,<memw>,<usedw>,<totalw>, <mems>,<useds>,<totals>
+ * +CPMS: <memr>,<usedr>,<totalr>,<memw>,<usedw>,<totalw>,<mems>,<useds>,<totals>
  */
 
 #define CPMS_QUERY_REGEX "\\+CPMS:\\s*\"(?P<memr>.*)\",[0-9]+,[0-9]+,\"(?P<memw>.*)\",[0-9]+,[0-9]+,\"(?P<mems>.*)\",[0-9]+,[0-9]"
@@ -3019,6 +3019,7 @@ gboolean
 mm_3gpp_parse_cpms_query_response (const gchar *reply,
                                    MMSmsStorage *memr,
                                    MMSmsStorage *memw,
+                                   MMSmsStorage *mems,
                                    GError **error)
 {
     g_autoptr(GRegex)     r = NULL;
@@ -3043,6 +3044,9 @@ mm_3gpp_parse_cpms_query_response (const gchar *reply,
         return FALSE;
 
     if (!mm_3gpp_get_cpms_storage_match (match_info, "memw", memw, error))
+        return FALSE;
+
+    if (!mm_3gpp_get_cpms_storage_match (match_info, "mems", mems, error))
         return FALSE;
 
     return TRUE;

--- a/src/mm-modem-helpers.h
+++ b/src/mm-modem-helpers.h
@@ -233,6 +233,7 @@ gboolean mm_3gpp_parse_cpms_test_response (const gchar  *reply,
 gboolean mm_3gpp_parse_cpms_query_response (const gchar *reply,
                                             MMSmsStorage *mem1,
                                             MMSmsStorage *mem2,
+                                            MMSmsStorage *mem3,
                                             GError** error);
 gboolean mm_3gpp_get_cpms_storage_match (GMatchInfo *match_info,
                                          const gchar *match_name,

--- a/src/tests/test-modem-helpers.c
+++ b/src/tests/test-modem-helpers.c
@@ -3161,13 +3161,14 @@ typedef struct {
     const gchar *query;
     MMSmsStorage mem1_want;
     MMSmsStorage mem2_want;
+    MMSmsStorage mem3_want;
 } CpmsQueryTest;
 
 CpmsQueryTest cpms_query_test[] = {
-    {"+CPMS: \"ME\",1,100,\"MT\",5,100,\"TA\",1,100", 2, 3},
-    {"+CPMS: \"SM\",100,100,\"SR\",5,10,\"TA\",1,100", 1, 4},
-    {"+CPMS: \"XX\",100,100,\"BM\",5,10,\"TA\",1,100", 0, 5},
-    {"+CPMS: \"XX\",100,100,\"YY\",5,10,\"TA\",1,100", 0, 0},
+    {"+CPMS: \"ME\",1,100,\"MT\",5,100,\"TA\",1,100", 2, 3, 6},
+    {"+CPMS: \"SM\",100,100,\"SR\",5,10,\"TA\",1,100", 1, 4, 6},
+    {"+CPMS: \"XX\",100,100,\"BM\",5,10,\"TA\",1,100", 0, 5, 6},
+    {"+CPMS: \"XX\",100,100,\"YY\",5,10,\"TA\",1,100", 0, 0, 6},
     {NULL, 0, 0}
 };
 
@@ -3175,6 +3176,7 @@ static void
 test_cpms_query_response (void *f, gpointer d) {
     MMSmsStorage mem1;
     MMSmsStorage mem2;
+    MMSmsStorage mem3;
     gboolean ret;
     GError *error = NULL;
     int i;
@@ -3183,11 +3185,13 @@ test_cpms_query_response (void *f, gpointer d) {
         ret = mm_3gpp_parse_cpms_query_response (cpms_query_test[i].query,
                                                  &mem1,
                                                  &mem2,
+                                                 &mem3,
                                                  &error);
         g_assert (ret);
         g_assert_no_error (error);
         g_assert_cmpuint (cpms_query_test[i].mem1_want, ==, mem1);
         g_assert_cmpuint (cpms_query_test[i].mem2_want, ==, mem2);
+        g_assert_cmpuint (cpms_query_test[i].mem3_want, ==, mem3);
     }
 }
 


### PR DESCRIPTION
SIM A7602E-H resets SMS storages to default SM, if they are omitted in AT+CPMS write command. So always send all 3 parameters.


https://wirenboard.bitrix24.ru/company/personal/user/134/tasks/task/view/70048/
MM перключает хранилище смс во время их чтения и удаления. Делает он это командой AT+CPMS с указанием только первого параметра. По стандарту, если параметр не указан, его значение не меняется, но прошивка A7602E-H сбрасывает их на значения по умолчанию. В результате все смс хранятся в сим-карте, что вызывает переполнение. Ещё MM считает, что смс лежат в памяти модема, и пытается удалить их из него, но реально смс на сим-карте. Из-за этого нельзя удалить полученные смс.
Сделал так, что MM в AT+CPMS всегда передаёт все параметры. Потестили с клиентом, всё корректно.